### PR TITLE
Check if the classic editor is not enabled via the plugin.

### DIFF
--- a/unique-title-checker.php
+++ b/unique-title-checker.php
@@ -157,7 +157,7 @@ class Unique_Title_Checker {
 		}
 
 		// Enqueue the script.
-		if ( function_exists( 'block_version' ) ) {
+		if ( function_exists( 'block_version' ) && get_option( 'classic-editor-replace' ) != 'classic' ) {
 			wp_enqueue_script( 'unique_title_checker', plugins_url( 'js/unique-title-checker-block-editor.js', __FILE__ ), array( 'jquery', 'wp-data', 'wp-notices' ), '1.4.1', true );
 		} else {
 			wp_enqueue_script( 'unique_title_checker', plugins_url( 'js/unique-title-checker.js', __FILE__ ), array( 'jquery' ), '1.4.1', true );

--- a/unique-title-checker.php
+++ b/unique-title-checker.php
@@ -157,7 +157,7 @@ class Unique_Title_Checker {
 		}
 
 		// Enqueue the script.
-		if ( function_exists( 'block_version' ) && get_option( 'classic-editor-replace' ) != 'classic' ) {
+		if ( function_exists( 'block_version' ) && 'classic' !== get_option( 'classic-editor-replace' ) ) {
 			wp_enqueue_script( 'unique_title_checker', plugins_url( 'js/unique-title-checker-block-editor.js', __FILE__ ), array( 'jquery', 'wp-data', 'wp-notices' ), '1.4.1', true );
 		} else {
 			wp_enqueue_script( 'unique_title_checker', plugins_url( 'js/unique-title-checker.js', __FILE__ ), array( 'jquery' ), '1.4.1', true );


### PR DESCRIPTION
After WP 5.0 we must use the [Classic Editor](https://wordpress.org/plugins/classic-editor/) plugin to fall back using the old WYSIWYG editor.

This additional check will also ensure that we are not using this plugin or have enabled the classic editor in his settings. So it will include the correct .js file. 

In my case the only check for `function_exists( 'block_version' )` was always returning `true`, since I'm on 5.3 and this function is now part of WP core. As a result was being enqueued `unique-title-checker-block-editor.js` instead of `unique-title-checker.js`, which is the right one that should have been loaded since I'm not using Gutenberg but the Classic Editor via the plugin.